### PR TITLE
Updated number of Bash-Patches

### DIFF
--- a/sources/script/functions.sh
+++ b/sources/script/functions.sh
@@ -360,7 +360,7 @@ cd ~/sources
 mkdir bash && cd $_
 echo "${info} Downloading GNU bash & latest security patches..." | awk '{ print strftime("[%H:%M:%S] |"), $0 }'
 wget https://ftp.gnu.org/gnu/bash/bash-4.3.tar.gz >/dev/null 2>&1
-for i in $(seq -f "%03g" 1 42); do wget http://ftp.gnu.org/gnu/bash/bash-4.3-patches/bash43-$i; done >/dev/null 2>&1
+for i in $(seq -f "%03g" 1 46); do wget http://ftp.gnu.org/gnu/bash/bash-4.3-patches/bash43-$i; done >/dev/null 2>&1
 tar zxf bash-4.3.tar.gz && cd bash-4.3 >/dev/null 2>&1
 echo "${info} Patching sourcefiles..." | awk '{ print strftime("[%H:%M:%S] |"), $0 }'
 for i in ../bash43-[0-9][0-9][0-9]; do patch -p0 -s < $i; done


### PR DESCRIPTION
Updated the number of GNU Bash patches from 42 to 46, which is the actual amount of available patches for Bash 4.3.